### PR TITLE
Agregar campos Color y License Plate

### DIFF
--- a/api/src/Models/Car.js
+++ b/api/src/Models/Car.js
@@ -45,9 +45,27 @@ module.exports = (sequelize) => {
           isValidRange: (val) => validator_validRange(val, "car", "year"),
         },
       },
-      patente: {
-        type: DataTypes.TEXT,
+      color: {
+        type: DataTypes.STRING(20),
         allowNull: false,
+        validate: {
+          isAlpha: {
+            msg: "car color is invalid, only letters",
+          },
+          isEmptyString: (val) => validator_emptyString(val, "car", "color"),
+          isAllowedLength: (val) =>
+            validator_validLength(val, "car", "model", 20),
+        },
+      },
+      license_plate: {
+        type: DataTypes.STRING(20),
+        allowNull: false,
+        validate: {
+          isEmptyString: (val) =>
+            validator_emptyString(val, "car", "license plate"),
+          isAllowedLength: (val) =>
+            validator_validLength(val, "car", "license plate", 20),
+        },
       },
       fuel: {
         type: DataTypes.STRING,


### PR DESCRIPTION
Campos
---
Agregue validaciones a la propiedad **color** y reemplace la propiedad patente por **license_plate** (para que todo este en ingles)  y tambien fue validada.

- **color**: tipo `string`, `obligatorio`, debe contener `solo letras`, `no debe ser vacio`, y no debe superar los `20` caracteres.

- ~~**patente**~~ -> **license_plate**: tipo `string`, `obligatorio`, `no debe ser vacio`, y no debe superar los `20` caracteres.
