### PR TITLE
Correccion de ruta /models

### DIFF
--- a/api/src/db.js
+++ b/api/src/db.js
@@ -15,10 +15,10 @@ const basename = path.basename(__filename);
 const modelDefiners = [];
 
 // Leemos todos los archivos de la carpeta Models, los requerimos y agregamos al arreglo modelDefiners
-fs.readdirSync(path.join(__dirname, '/models'))
+fs.readdirSync(path.join(__dirname, '/Models'))
   .filter((file) => (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js'))
   .forEach((file) => {
-    modelDefiners.push(require(path.join(__dirname, '/models', file)));
+    modelDefiners.push(require(path.join(__dirname, '/Models', file)));
   });
 
 // Injectamos la conexion (sequelize) a todos los modelos


### PR DESCRIPTION
Remplazo la ruta `/models` por `/Models` para evitar problemas al intentar buscar los modelos.