### PR TITLE
IMPORTANTE: Definir que API consulta el cliente(Heroku/LocalHost)

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,11 +1,10 @@
+const server = require("./src/app.js");
+const { conn } = require("./src/db.js");
 
-const server = require('./src/app.js');
-const { conn } = require('./src/db.js');
-
-const PORT = process.env.PORT || 3001
+const PORT = process.env.PORT || 3001;
 // Syncing all the models at once.
 conn.sync({ force: true }).then(() => {
   server.listen(PORT, () => {
-    console.log('% listening at 3001'); // eslint-disable-line no-console
+    console.log(`% listening at ${PORT}`); // eslint-disable-line no-console
   });
 });

--- a/client/src/config/enviroment.js
+++ b/client/src/config/enviroment.js
@@ -1,0 +1,5 @@
+const { REACT_APP_API_URL, REACT_APP_API_PORT } = process.env;
+export const API_URL =
+  REACT_APP_API_URL === "localhost"
+    ? `http://${REACT_APP_API_URL}:${REACT_APP_API_PORT}`
+    : `https://${REACT_APP_API_URL}`;

--- a/client/src/redux/actions/getSearch.js
+++ b/client/src/redux/actions/getSearch.js
@@ -1,9 +1,10 @@
 import axios from 'axios';
+import {API_URL} from "../../config/enviroment";
 export const GET_SEARCH_FOR_DESTINATION = 'GET_SEARCH';
 
 export function getSearch(destination) {
     return async function pedido(dispatch) {
-        let pedidoAlBack = await axios.get(`https://on-drive.herokuapp.com/api/static/${destination}`);
+        let pedidoAlBack = await axios.get(`${API_URL}/api/static/${destination}`);
         return dispatch({
             type: GET_SEARCH_FOR_DESTINATION,
             payload: pedidoAlBack.data,

--- a/client/src/redux/actions/getTrips.js
+++ b/client/src/redux/actions/getTrips.js
@@ -1,9 +1,10 @@
 import axios from 'axios';
+import {API_URL} from "../../config/enviroment";
 export const GET_TRIPS = "GET_TRIPS";
 
 export const getTrips = (destination) => {
     return async function (dispatch) {
-        axios.get("https://on-drive.herokuapp.com/api/static"
+        axios.get(`${API_URL}/api/static`
         ).then(trips => dispatch({ type: GET_TRIPS, payload: trips.data })
         ).catch(c => console.log(c))
     }


### PR DESCRIPTION
Definir que API consulta el cliente(Heroku/LocalHost)
--
A partir de ahora en la carpeta **`/client`** deben crear un archivo `.env` que contenga la siguiente informacion:

**Archivo .env:**
```
REACT_APP_API_URL=localhost
REACT_APP_API_PORT=3001
```
El `REACT_APP_API_PORT` puede ser cualquiera siempre y cuando coincida con el `PUERTO` en el que levantan el servidor(back).

Todo esto lo hacemos para poder probar nuevas funcionalidades en el back **_sin tener que desplegarlo a heroku_** constanemente, es decir poder trabajar localmente como lo veniamos haciendo, osea levantamos nuestro **FRONT**, nuestro **BACK** y desarrollamos tranquilos.

**Directorio /config:**
Cree un directorio `/config` que contiene un archivo llamado `enviroment.js`, este archivo exporta una variable llamada `API_URL`, sera la que se utilice a partir de ahora para realizar peticiones al backend.

**Archivo enviroment.js:**
Se encarga de definir una variable **`API_URL`**, que sera http://localhost:3001 si estamos trabajando en local o sera https://on-drive.herokuapp.com/ cuando nuestro cliente consulte desde Vercel

**Ejemplo de como realizar peticiones a partir de ahora:**
- Siempre deben importar `API_URL` desde `config/enviroment.js` y utlizar esa ruta base.
```javascript
import {API_URL} from "../../config/enviroment";

let pedidoAlBack = await axios.get(`${API_URL}/ejemplo/prueba/1`);
let pedidoAlBack2 = await axios.get(`${API_URL}/otro`);
let pedidoAlBack3 = await axios.post(`${API_URL}/crearAlgo`,{ nombre: "esto es", apellido: "un ejemplo"});
```

**Resumen**
--
Creen un archivo `.env` en la carpeta `/client`, agreguen dichos datos e importen siempre que realicen peticiones al back la constante `API_URL`, y continuen trabajando normalmente :partying_face: :partying_face: :partying_face: 