### PR TITLE
Seguridad en las contraseñas

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^0.27.2",
+    "bcrypt": "^5.0.1",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "dotenv": "^8.6.0",

--- a/api/src/Models/Admin.js
+++ b/api/src/Models/Admin.js
@@ -15,7 +15,7 @@ const Admin = conn.define(
       unique: true,
     },
     password: {
-      type: DataTypes.STRING(45),
+      type: DataTypes.STRING(100),
       allowNull: false,
     },
   },

--- a/api/src/Models/User.js
+++ b/api/src/Models/User.js
@@ -15,7 +15,7 @@ const User = conn.define(
       unique: true,
     },
     password: {
-      type: DataTypes.STRING(45),
+      type: DataTypes.STRING(100),
       allowNull: true,
     },
     name: {

--- a/api/src/Models/utils/Admin.js
+++ b/api/src/Models/utils/Admin.js
@@ -1,24 +1,28 @@
 const { Admin } = require("../../Models/Admin"); //admin model
-const { User } = require('../../Models/User');
+const { User } = require("../../Models/User");
+const bcrypt = require("bcrypt");
 
 //PARA AGREGAR UN NUEVO ADMIN A LA TABLA(NO UTILIZAR)
 async function createAdmin({ username, password }) {
   try {
-    const [admin, created] = await Admin.findOrCreate({
+    //hash pass
+    const passwordHash = await bcrypt.hash(password, 15);
+
+    const [_admin, created] = await Admin.findOrCreate({
       where: { username },
-      defaults: { username, password },
+      defaults: { username, password: passwordHash },
     });
 
     return created
       ? {
-          msg: "admin/s ready",
+          msg: "Administradores Listos.",
         }
       : {
-          msg: "error loading admins(not initialized)",
+          msg: "Error al cargar los usuarios Administradores",
         };
   } catch (e) {
     return {
-      msg: "error on create admin - " + e.message,
+      msg: "Error al crear los Administradores - " + e.message,
     };
   }
 }
@@ -26,11 +30,19 @@ async function createAdmin({ username, password }) {
 //PARA VER SI UN USERNAME & PASSWORD ES DE UN ADMIN O NO
 async function verifyAdmin({ username, password }) {
   try {
-    const admin = await Admin.findOne({ where: { username, password } });
+    const admin = await Admin.findOne({ where: { username } });
     if (admin === null) return false;
-    return true;
+
+    //check password
+    const valid = await bcrypt.compare(
+      password,
+      admin.getDataValue("password")
+    );
+
+    return valid; //(true or false)
   } catch (e) {
-    return { msg: "error verify admin - " + e.message };
+    console.error("Error al verificar el administrador - " + e.message);
+    return false;
   }
 }
 
@@ -43,7 +55,7 @@ async function administrator() {
     });
     console.log(msg);
   } catch (e) {
-    console.error("error initialization admin - " + e.message);
+    console.error(e.message);
   }
 }
 

--- a/api/src/controllers/adminController.js
+++ b/api/src/controllers/adminController.js
@@ -1,5 +1,4 @@
-const { setBanStatus } = require("../Models/utils/Admin");
-const { Admin } = require("../Models/Admin"); //admin model
+const { setBanStatus, verifyAdmin } = require("../Models/utils/Admin");
 const jwt = require("jsonwebtoken");
 const { SECRET_KEY } = process.env;
 
@@ -28,8 +27,8 @@ async function unbanUser(req, res) {
 async function logAdmin(req, res) {
   const { username, password } = req.body;
   try {
-    const admin = await Admin.findOne({ where: { username, password } });
-    if (!admin)
+    const valid = await verifyAdmin({ username, password });
+    if (!valid)
       return res
         .status(400)
         .json({ error: "Usuario o contraseña incorrecta." });
@@ -40,27 +39,4 @@ async function logAdmin(req, res) {
   }
 }
 
-// const checkUserIsAdmin = async (req, res) => {
-//   let token = req.headers["authorization"];
-//   token = token.split(" ")[1];
-
-//   if (token !== "null") {
-//     jwt.verify(token, SECRET_KEY, (err, decoded) => {
-//       if (err) {
-//         return res.status(401).json({ message: "Invalid Token." });
-//       } else {
-//         if (decoded.hasOwnProperty("isAdmin")) {
-//           return res.status(202).json({ message: "The user is allowed." });
-//         } else {
-//           return res.status(403).json({ message: "The user is not allowed." });
-//         }
-//       }
-//     });
-//   } else {
-//     res.status(40).json({
-//       message: "Token not provided.",
-//     });
-//   }
-// };
-
-module.exports = { banUser, unbanUser, logAdmin};
+module.exports = { banUser, unbanUser, logAdmin };

--- a/api/src/controllers/authController.js
+++ b/api/src/controllers/authController.js
@@ -1,4 +1,5 @@
 const { findAllUsers, findUserById } = require("../Models/utils/Finders");
+const bcrypt = require("bcrypt");
 const {
   isCorrectCredentials,
   isFitToBuy,
@@ -10,17 +11,25 @@ const {
 } = require("../Models/utils/Creations");
 
 const jwt = require("jsonwebtoken");
-const { response } = require("express");
 const { SECRET_KEY } = process.env;
 
 const registerUser = async (req, res) => {
   try {
     const { email, password, name, last_name } = req.body;
-    if (!email) throw new Error("mandatory data is missing");
-    let user_id = await createUser({ email, password, name, last_name });
-  
+    if (!email) throw new Error("Se necesita el email obligatoriamente");
+
+    const passwordHash = await bcrypt.hash(password, 10); //hash password
+    let user_id = await createUser({
+      email,
+      password: passwordHash,
+      name,
+      last_name,
+    });
+
     if (!user_id)
-      return res.status(409).json({ error: "Ya existe un usuario registrado con este mail." });
+      return res
+        .status(409)
+        .json({ error: "Ya existe un usuario registrado con este mail." });
 
     const token = jwt.sign({ id: user_id }, SECRET_KEY, {
       expiresIn: "1h",
@@ -36,7 +45,7 @@ async function registerDriver(req, res) {
   try {
     const { user_id, driver } = req.body;
     const driver_id = await createDriver(user_id, driver);
-    if (!driver_id) throw new Error("unexpected error");
+    if (!driver_id) throw new Error("Algo salio mal al crear el conductor");
     res.status(201).json({ driver_id });
   } catch (e) {
     res.status(400).json({ error: e.message });
@@ -57,41 +66,46 @@ const loginUser = async (req, res) => {
     });
     res.json({ token }); //return token JWT
   } catch (e) {
-    console.log(e);
+    console.error(e);
     res.status(400).json({ error: `${e.message}` });
   }
 };
 
-
 const verifyUser = async (req, res) => {
-  const {caso, decoded} = req.body
-  let user = null
-  if(res.status > 400) return res.send('') 
-  try{
-    switch(caso){
-      case 'googleUser':
-          user = await findUserById({user_id: decoded.id})
-          if(!user.password) return res.status(202).json({ message: 'The user is allowed.'})
-          else return res.status(403).json({ message: "Page users not allowed." });
-  
-      case 'pageUser':
-        if(!decoded.hasOwnProperty('id')) return res.status(400).json('No soy un usuario común.')
-        user = await findUserById({user_id: decoded.id})
-        if(!user.password) return res.status(403).json({ message: 'Google users not allowed.'})
-        else return res.status(202).json({ message: 'The user is allowed.' });
-      
-      case 'admin':
-        if (decoded.hasOwnProperty("isAdmin")) return res.status(202).json({ message: "The user is allowed." });
-        else return res.status(403).json({ message: "The user is not allowed." });
-      
+  const { caso, decoded } = req.body;
+  let user = null;
+  if (res.status > 400) return res.send("");
+  try {
+    switch (caso) {
+      case "googleUser":
+        user = await findUserById({ user_id: decoded.id });
+        if (!user.password)
+          return res.status(202).json({ message: "The user is allowed." });
+        else
+          return res.status(403).json({ message: "Page users not allowed." });
+
+      case "pageUser":
+        if (!decoded.hasOwnProperty("id"))
+          return res.status(400).json("No soy un usuario común.");
+        user = await findUserById({ user_id: decoded.id });
+        if (!user.password)
+          return res.status(403).json({ message: "Google users not allowed." });
+        else return res.status(202).json({ message: "The user is allowed." });
+
+      case "admin":
+        if (decoded.hasOwnProperty("isAdmin"))
+          return res.status(202).json({ message: "The user is allowed." });
+        else
+          return res.status(403).json({ message: "The user is not allowed." });
+
       default:
-        return res.status(200).send('Genial')
+        return res.status(200).send("Genial");
     }
-  } catch(e){
-    console.log(e)
-    res.status(500).json(e)
+  } catch (e) {
+    console.log(e);
+    res.status(500).json(e);
   }
-}
+};
 
 const getUsers = async (req, res) => {
   try {
@@ -116,12 +130,12 @@ const purchaseTrip = async (req, res) => {
   try {
     const { user_id, trip_id } = req.body;
     if (!user_id || !trip_id)
-    throw new Error("crucial data is missing(user id or trip id)");
+      throw new Error("Faltan datos del viaje o del usuario");
     const canBuy = await isFitToBuy(user_id, trip_id);
     if (!canBuy)
-    return res
-    .status(401)
-    .json({ error: "you are not authorized to buy this trip" });
+      return res
+        .status(401)
+        .json({ error: "No estas autorizado para comprar este viaje" });
     //vincular viaje
     const trip = await assingTrip({ user_id, trip_id });
     res.json({ trip_purchased: trip });
@@ -130,66 +144,6 @@ const purchaseTrip = async (req, res) => {
   }
 };
 
-// const checkUserIsLoggedWithGoogle = async (req, res) => {
-  //   try {
-//     let token = req.headers["authorization"];
-//     token = token.split(" ")[1];
-
-//     if (token !== "null") {
-//       jwt.verify(token, SECRET_KEY, async (err, decoded) => {
-//         if(err) return res.status(401).json({ message: "Invalid Token." })
-//         else{
-//           const user = await findUserById({user_id: decoded.id})
-//           if(!user.password){
-//             return res.status(202).json({ message: 'The user is allowed.'})
-//           } else{
-//             return res.status(403).json({ message: "Page users not allowed." });
-//           }
-//         }
-//       });
-//     } else res.status(404).json({ message: "Token not provided." });
-//   } catch (e) {
-//     res.status(400).json({ error: `${e.message}` });
-//   }
-// }
-
-// const checkUserIsLogged = async (req, res) => {
-  //   try {
-    //     let token = req.headers["authorization"];
-//     token = token.split(" ")[1];
-//     if (token !== "null") {
-  //       jwt.verify(token, SECRET_KEY, async (err, decoded) => {
-//         if(err) return res.status(401).json({ message: "Invalid Token." })
-//         else{
-//           const user = await findUserById({user_id: decoded.id})
-//           if(!user.password){
-  //             return res.status(403).json({ message: 'Google users not allowed'})
-  //           } else{
-    //             return res.status(202).json({ message: "The user is allowed." });
-    //           }
-    //         }
-    //       });
-    //     } else res.status(404).json({ message: "Token not provided." });
-//   } catch (e) {
-//     res.status(400).json({ error: `${e.message}` });
-//   }
-// };
-
-// const checkUserIsNotLogged = async(req, res) => {
-//   try {
-//     let token = req.headers["authorization"];
-//     token = token.split(" ")[1];
-//     if (token !== "null") {
-//       jwt.verify(token, SECRET_KEY, async (err, decoded) => {
-//         if(err) return res.status(401).json({ message: "Invalid Token." })
-//         else return res.status(202).json({ message: "The user is allowed." });
-//       });
-//     } else res.status(404).json({ message: "Token not provided." });
-//   } catch (e) {
-//     res.status(400).json({ error: `${e.message}` });
-//   }
-// }
-
 module.exports = {
   registerUser,
   getUsers,
@@ -197,5 +151,5 @@ module.exports = {
   registerDriver,
   loginUser,
   purchaseTrip,
-  verifyUser
+  verifyUser,
 };


### PR DESCRIPTION
Seguridad en las contraseñas de los usuarios 🔐 
-
Primero que nada utilice una liberia de encriptacion unidireccional, esto es muy seguro pero hay un problema que tenemos que solucionar, **lo detallo al final ⬇️** **LEER :pray:**  .

**Liberia [bcrypt](https://github.com/kelektiv/node.bcrypt.js/)**: nos permite hashear datos, y definir una complejidad computacional(_mas alta es, mas tarda, pero es mas segura_) con la que hashear el/los datos 🥷 .
En nuestro caso, al intentar iniciar sesion lo que sea hace es enviar la contraseña, hashearla y compararla con la contraseña hasheada.
Por lo que nunca se permite es recuperar la password original de la base de datos.

# Registro 
Supongamos que el usuario envia todos sus datos y una contraseña al registrarse:
![imagen](https://user-images.githubusercontent.com/71911407/179632118-d8c0a99f-599c-45d6-9bf3-1994b6bb27c3.png)

> De esta forma ni siquiera nostros tendremos acceso a la password del usuario :open_mouth:
# Login 
Ahora veamos como es el flujo al iniciar sesion en la pagina:
![imagen](https://user-images.githubusercontent.com/71911407/179631916-6d7d4605-00a7-4c3b-9161-6e7603b822cf.png)

# Problema :x: 
Esto es perfecto y funciona, el problema es que ahora al intentar recuperar tu password, ya no se puede enviar el email, en realidad si se envia pero llega hasheada, ya que nadie conoce la password del usuario, ni siquiera nosotros. :cry: .

# Solucion propuesta:
Lo que propongo para solucionar este problema es lo siguiente:
Agregamos un nuevo campo al modelo :bust_in_silhouette: user llamado `code_recovery`, que por defecto este en **null**.
Entonces cuando un usuario pierde u olvida su password, ingrese su email, pero en lugar de enviarle la password, le enviemos un codigo generado aleatoriamente, antes de enviarselo lo seteamos en su campo  `code_recovery`, luego el usuario tendra que ingresar ese codigo, una vez que lo ingresa accede a su cuenta y  se elimina de su campo  `code_recovery`, y al ya estar logeado podra acceder a /new-password y cambiarla desde ahi. :smile: 
**Lo explico con un diagrama que por ahi se entiende mejor:**
![imagen](https://user-images.githubusercontent.com/71911407/179634590-75505aef-bc34-4c3e-844d-408c541c9725.png)
Obviamente tenemos que agregar algo en el **front** donde ingrese el codigo, pensaba hacerlo debajo del input en el que ingresa el email para recuperar la password, y que en lugar de redirigirlo al login al enviar el email, que le permite ingresar el codigo y ahi enviarlo y compararlo.
No tengo drama en hacer lo del front :dancers: 
### Espero su opinion gente, si me dan el :heavy_check_mark:  lo hago sin problemas: 




